### PR TITLE
fix: include full day range in orders by date

### DIFF
--- a/src/app/api/orders/by-date/route.ts
+++ b/src/app/api/orders/by-date/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
         // Parse the date and get start/end of day
         const date = new Date(dateStr);
         const startOfDay = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0);
-        const endOfDay = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59);
+        const endOfDay = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999);
 
         const orders = await db.order.findMany({
             where: {


### PR DESCRIPTION
## Summary
- ensure `endOfDay` includes the final millisecond to capture all orders on the specified date

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689bab85e9a08333893a40b23a08c35c